### PR TITLE
Update Request.cs

### DIFF
--- a/Models/Request.cs
+++ b/Models/Request.cs
@@ -3,7 +3,7 @@
 namespace Arex388.SunriseSunset.Models {
 	public sealed class Request {
 		public DateTime DateOn { get; set; }
-		public string Endpoint => $"https://api.sunrise-sunset.org/json?lat={Latitude}&lng={Longitude}&date={DateOn:yyyy-MM-dd}&formatted=0";
+		public string Endpoint => $"https://api.sunrise-sunset.org/json?lat={Latitude.ToString(CultureInfo.InvariantCulture)}&lng={Longitude.ToString(CultureInfo.InvariantCulture)}&date={DateOn:yyyy-MM-dd}&formatted=0";
 		public decimal Latitude { get; set; }
 		public decimal Longitude { get; set; }
 	}


### PR DESCRIPTION
If the number separator is "," in the regional settings, the API query was generated incorrectly. The coordinates had a comma.